### PR TITLE
CDD-404 Fix 'N/A' on the page while the required key in the Redis cache is not present

### DIFF
--- a/coronavirus_dashboard_summary/Views/Views.HomePage.fs
+++ b/coronavirus_dashboard_summary/Views/Views.HomePage.fs
@@ -20,12 +20,20 @@ let index (date: Release) (redis: Redis.Client) =
         |> List.groupBy Filters.GroupByMetric
         |> List.map Filters.GroupByPriorityAttribute
         |> Metrics.GeneralPayload
+
+    let dbData =
+        if dbResp.Count = 0 then HomePageModel.Data date Metrics.PostCodeMetrics redis
+                                 |> Async.RunSynchronously
+                                 |> List.groupBy Filters.GroupByMetric
+                                 |> List.map Filters.GroupByPriorityAttribute
+                                 |> Metrics.GeneralPayload
+        else dbResp
         
     [
         yield! HomeHeading.Render
                     
         MetaData.CardMetadata
-        |> Array.Parallel.map (fun metadata -> metadata.Card date dbResp null)
+        |> Array.Parallel.map (fun metadata -> metadata.Card date dbData null)
         |> List.concat
         |> Body.Render
     ]


### PR DESCRIPTION
If the required key can't be found in redis, then it will be fetched from postgres db directly.
Before the fix no data was read from db for the home page.