### PR TITLE
COV-4 Modify query to get nested metrics

### DIFF
--- a/coronavirus_dashboard_summary/Views/Views.PostCode.fs
+++ b/coronavirus_dashboard_summary/Views/Views.PostCode.fs
@@ -63,6 +63,18 @@ WHERE area_id = @areaid
   AND payload IS NOT NULL)
 ORDER BY rank LIMIT 1;
 "
+
+type Payload =
+    {
+        date:      string
+        area_code: string
+        area_type: string
+        area_name: string
+        metric:    string
+        value:     string option
+        priority:  int
+    }
+
 let private DBConnection =
     Sql.host (Environment.GetEnvironmentVariable "POSTGRES_HOST")
     |> Sql.database (Environment.GetEnvironmentVariable "POSTGRES_DATABASE")


### PR DESCRIPTION
These changes are related only to the code that's
going to be executed if the relevant data can't
be found in the redis cache.
The modified sql query gets the nested metrics data. 2 new objects are added (after serialization)
to the redis cache - db response object is different, so the serialization had to be modified.